### PR TITLE
Update bindings to compile under multiple node versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /node_modules/
 npm-debug.log
+build
+.idea

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## Updated to compile under all versions of NodeJS
+Forked from https://github.com/pingjiang/node-rar.
+
+I needed this module for nodejs >= 0.12. My pull request has been in for many months
+with no update and I believe the project may be abandoned, so I published this under
+an updated name so I could continue to use it in my projects. If the pull request is
+accepted in the original project, or the original project is updated, I will remove
+this package and repository. The module now works under all versions of NodeJS.
+
 #  Node Rar Addon [![Build Status](https://secure.travis-ci.org/pingjiang/node-rar.png?branch=master)](http://travis-ci.org/pingjiang/node-rar)
 
 Node Rar Addon for reading RAR archives using the bundled UnRAR library.

--- a/package.json
+++ b/package.json
@@ -1,18 +1,20 @@
 {
-  "name": "node-rar",
-  "version": "0.0.2",
+  "name": "node-rar-updated",
+  "version": "0.0.1",
   "main": "lib/rar.js",
-  "description": "Node Rar Addon for reading RAR archives using the bundled UnRAR library.",
-  "homepage": "https://github.com/pingjiang/node-rar",
-  "bugs": "https://github.com/pingjiang/node-rar/issues",
+  "description": ["Updated Node Rar Addon for reading RAR archives using the ",
+    "bundled UnRAR library. Works with all versions of NodeJS. Forked from original ",
+    "node-rar at https://github.com/pingjiang/node-rar"],
+  "homepage": "https://github.com/davidcroda/node-rar",
+  "bugs": "https://github.com/davidcroda/node-rar/issues",
   "author": {
-    "name": "pingjiang",
-    "email": "pingjiang1989@gmail.com",
-    "url": "https://github.com/pingjiang"
+    "name": "davidcroda",
+    "email": "davidcroda@gmail.com",
+    "url": "https://github.com/davidcroda"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pingjiang/node-rar"
+    "url": "https://github.com/davidcroda/node-rar"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
v8 0.12 has a number of breaking changes, and this module can no longer be installed on many systems which default to node 0.12+ 

I updated it to the current API.  It compiles on Node v0.12.5.  All tests pass.

Fixes #2 
